### PR TITLE
🚑 Hot Fix - Docker File Path Error

### DIFF
--- a/.github/workflows/dev_api_server_cicd.yml
+++ b/.github/workflows/dev_api_server_cicd.yml
@@ -50,7 +50,6 @@ jobs:
 
     ### project build
     - name: Build with Gradle
-      if: github.event.pull_request.merged == true
       run: |
         cd ./Dev/API-Server
         ./gradlew clean build -x test

--- a/Dev/API-Server/Dockerfile
+++ b/Dev/API-Server/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:17-alpine
 
 WORKDIR /app
 
-ARG JAR_PATH=./build/libs
+ARG JAR_PATH=./Dev/API-Server/build/libs
 
 COPY ${JAR_PATH}/application.jar app.jar
 


### PR DESCRIPTION
## 관련 이슈

- Resolves : #57 
 
## 작업 사항

- Docker File에서의 JAR_PATH를 Mono Repository에 맞춰 수정함

## 참고 사항

없습니다.

